### PR TITLE
fixed updated tree

### DIFF
--- a/src/optimizer/core/mcts.py
+++ b/src/optimizer/core/mcts.py
@@ -122,8 +122,9 @@ def update_tree(paths: dict, new_node: KernelNode):
         if current.id not in parent.children_ids:
             parent.children_ids.append(current.id)
 
-        # 2. Update visits
-        parent.visits += 1
+        # 2. Only update the immediate parent's visits, not all ancestors
+        if current.id == new_node.id:
+             parent.visits += 1
 
         # 3. Update best_subtree_value
         parent_best = parent.best_subtree_value if parent.best_subtree_value is not None else parent.value


### PR DESCRIPTION
Fixed bug that updates ALL ancestors' visit count when child node generated.

Example tree:
```
Root->node1->node2
```

Intended behavior for creating node 2 off of node 1 should be to increment node1's visit count but not root's visit count

