### PR TITLE
fix: align ancestor_code_depth default with actual prompt behavior

### DIFF
--- a/src/optimizer/config/settings.py
+++ b/src/optimizer/config/settings.py
@@ -98,7 +98,7 @@ try:
         llm_model_name: str = "anthropic/claude-sonnet-4-6"
         cuda_home: str = _DEFAULT_CUDA_HOME
         retry_limit: int = 3
-        ancestor_code_depth: int = 3
+        ancestor_code_depth: int = 1
 
         model_config = SettingsConfigDict(env_prefix="OPTIMIZER_")
 
@@ -114,6 +114,6 @@ except Exception:
         llm_model_name: str = "anthropic/claude-sonnet-4-6"
         cuda_home: str = _DEFAULT_CUDA_HOME
         retry_limit: int = 3
-        ancestor_code_depth: int = 3
+        ancestor_code_depth: int = 1
 
     settings = _load_from_env("OPTIMIZER_", PipelineConfig)


### PR DESCRIPTION
## Summary
  - `ancestor_code_depth` defaulted to `3` in both pydantic and
  dataclass configs, but the optimization prompt always discards
  all but the last ancestor code blob (`ancestor_codes[-1]`),
  making the extra fetches wasted DB reads
  - Changed default to `1` to match actual behavior